### PR TITLE
refactor(repeater): stop sending ping

### DIFF
--- a/src/sec_tester/repeater.cr
+++ b/src/sec_tester/repeater.cr
@@ -23,19 +23,6 @@ module SecTester
         }
       )
       deploy
-      spawn do
-        heartbeat
-      end
-    end
-
-    private def heartbeat
-      loop do
-        sleep 10.seconds
-        break unless @running
-        @socket.emit("ping")
-      end
-    rescue e : Exception
-      Log.error { "Repeater heartbeat error: #{e.message}" }
     end
 
     def deploy


### PR DESCRIPTION
Ping historically was there to signal over RMQ that repeater is still connected
Socket.IO implementation has built in mechanism for disconnection detection https://socket.io/docs/v4/engine-io-protocol/#heartbeat